### PR TITLE
Update for react-router@1.0.0-beta4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "react": "^0.14.0-beta3",
     "react-relay": "^0.2.0",
-    "react-router": "1.0.0-beta3"
+    "react-router": "^1.0.0-beta4"
   },
   "devDependencies": {
     "babel": "^5.8.23",
@@ -47,7 +47,7 @@
     "eslint-plugin-react": "^3.3.0",
     "react": "^0.14.0-beta3",
     "react-relay": "^0.2.0",
-    "react-router": "1.0.0-beta3",
+    "react-router": "^1.0.0-beta4",
     "rimraf": "^2.4.3"
   }
 }

--- a/src/RouteAggregator.js
+++ b/src/RouteAggregator.js
@@ -19,7 +19,12 @@ export default class RouteAggregator {
   }
 
   updateRoute(routerProps) {
-    const {branch, params, location} = routerProps;
+    const {params, location} = routerProps;
+
+    // TODO: Replace this hack with a proper way of reading routes.
+    const {routes} = location;
+    location.hasRoutes = true;
+    console.log(routes);
 
     const relayRoute = {
       name: null,
@@ -28,7 +33,7 @@ export default class RouteAggregator {
     };
     const fragmentSpecs = {};
 
-    branch.forEach(route => {
+    routes.forEach(route => {
       const {queries} = route;
       if (!queries) {
         return;
@@ -47,7 +52,7 @@ export default class RouteAggregator {
         component.displayName || component.name
       );
 
-      const routeParams = getParamsForRoute({route, branch, params, location});
+      const routeParams = getParamsForRoute({route, params, location});
       Object.assign(relayRoute.params, routeParams);
 
       Object.keys(queries).forEach(queryName => {

--- a/src/createElement.js
+++ b/src/createElement.js
@@ -3,6 +3,12 @@ import React from 'react';
 import Container from './Container';
 
 export default function createElement(Component, props) {
+  // TODO: Replace this hack with a proper way of reading routes.
+  if (!props.location.hasRoutes) {
+    const childRoutes = props.location.routes || [];
+    props.location.routes = [props.route, ...childRoutes];
+  }
+
   return (
     <Container
       Component={Component}

--- a/src/getParamsForRoute.js
+++ b/src/getParamsForRoute.js
@@ -1,10 +1,10 @@
-import {getRouteParams} from 'react-router/lib/RoutingUtils';
+import getRouteParams from 'react-router/lib/getRouteParams';
 
-export default function getParamsForRoute({route, branch, params, location}) {
+export default function getParamsForRoute({route, params, location}) {
   const paramsForRoute = {};
 
   // Extract route params for current route and all ancestors.
-  for (const branchRoute of branch) {
+  for (const branchRoute of location.routes) {
     Object.assign(paramsForRoute, getRouteParams(branchRoute, params));
     if (branchRoute === route) {
       break;


### PR DESCRIPTION
`branch` is gone and its replacement `routes` is no longer passed down to components. I hacked around it for now.