### PR TITLE
Add support for shared queries and update docs

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -38,7 +38,7 @@ export default class Container extends React.Component {
 
     const params = getParamsForRoute(routerProps);
     const {fragmentPointers, failure} =
-      routeAggregator.getData(queries, params);
+      routeAggregator.getData(route, queries, params);
 
     let shouldUpdate = true;
     let element;


### PR DESCRIPTION
The query definitions in the README were actually wrong :x

This is helpful with Relay 0.2.1 because the shorthand really means that you just want the same queries for all of your routes (and maybe we should add some convenience thing for that, like `defaultQueries` that gets propagated downward), but it's actually fixing an existing bug.