### PR TITLE
Improve README example for fetching items by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,19 +74,21 @@ If your route doesn't have any dependencies on Relay data, just don't declare `q
 Any URL parameters for routes with queries and their ancestors will be used as parameters on the Relay route. You can then use these route parameters as variables on your containers:
 
 ```js
+const WidgetQueries = {
+  widget: () => Relay.QL`
+    query {
+      widget(widgetId: $widgetId) # `widgetId` receives a value from the route
+    }
+  `,
+}
+
 class Widget extends React.Component { /* ... */ }
 
 Widget = Relay.createContainer(Widget, {
-  initialVariables: {
-    widgetId: null
-  },
-
   fragments: {
-    viewer: () => Relay.QL`
-      fragment on User {
-        widget(widgetId: $widgetId) {
-          name
-        }
+    widget: () => Relay.QL`
+      fragment on Widget {
+        name
       }
     `
   }
@@ -96,7 +98,7 @@ Widget = Relay.createContainer(Widget, {
 const widgetRoute = (
   <Route
     path="widgets/:widgetId" component={Widget}
-    queries={ViewerQueries}
+    queries={WidgetQueries}
   />
 );
 ```


### PR DESCRIPTION
This corrects the example for fetching a single widget by ID from using a field on the fragment (an anti-pattern) to specifying the ID in the *route query*.

Relay Containers are designed to be *relative*: they should not specify the ID of the item that will be fetched. This should be specified instead by the parent. This generally means having a route such as:

```javascript
var route = {
  variables: { id: 123 },
  queries: {
    user: () => Relay.QL`query { user(id: $id) }`
};
```

And a container such as:

```javascript
Relay.createContainer(UserView, {
  fragments: {
    user: () => Relay.QL`
      fragment on User { # note that the user ID is specified by the *parent*
        name
      }
    `
...
```