### PR TITLE
Implement prepareParams on route

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,31 @@ const widgetListRoute = (
 );
 ```
 
-All URL and query parameters will be passed to the container as strings. Any missing query or state parameters will be treated as `null`. If you need to convert or initialize those values, you can do so in `prepareVariables` on the container.
+All URL and query parameters will be passed to the container as strings. Any missing query or state parameters will be treated as `null`. If you need to convert or initialize those values, you can do so with `prepareParams`:
+
+```javascript
+// `prepareParams` is a callback that `react-router-relay` calls with the
+// current `params` and `route` instance. It must return an object describing
+// the modified set of params. Use object spread syntax (`{...params}`) or
+// `Object.assign(...)` to include the original values along with overrides.
+var prepareParams = (params, route) => {
+  return {
+    ...params,
+    color: params.color || 'blue',
+    limit: parseInt(params.limit, 10),
+  };
+};
+
+const widgetListRoute = (
+  <Route
+    path="widgets" component={WidgetList}
+    queries={ViewerQueries}
+    queryParams={['color']}
+    stateParams={['limit']}
+    prepareParams={prepareParams}
+  />
+);
+```
 
 ### Render Callbacks
 

--- a/src/getParamsForRoute.js
+++ b/src/getParamsForRoute.js
@@ -25,9 +25,26 @@ export default function getParamsForRoute({route, routes, params, location}) {
     }
   }
 
-  return Object.assign(
+  Object.assign(
     paramsForRoute,
     getLocationParams(route.queryParams, location.query),
     getLocationParams(route.stateParams, location.state)
   );
+
+  var prepareParams = route.prepareParams;
+  if (prepareParams) {
+    if (typeof prepareParams !== 'function') {
+      throw new Error(
+        'react-router-relay: Expected `prepareParams` to be a function.'
+      );
+    }
+    paramsForRoute = prepareParams(paramsForRoute, route);
+    if (typeof paramsForRoute !== 'object' || paramsForRoute === null) {
+      throw new Error(
+        'react-router-relay: Expected `prepareParams` to return an object.'
+      );
+    }
+  }
+
+  return paramsForRoute;
 }


### PR DESCRIPTION
Addresses #59 and [this SO question](http://stackoverflow.com/questions/32860822/how-to-pass-value-to-the-root-query-in-react-router-relay) by implementing `prepareVariables` support on route configs.