### PR TITLE
Depend on latest react-relay package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.0",
-    "react-relay": "^0.3.2",
+    "react-relay": "^0.4.0",
     "react-router": "^1.0.0-rc1"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm having trouble updating to react-relay 0.4.0 because of this peer dependency:
```
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package react-relay@0.4.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-router-relay@0.6.2 wants react-relay@^0.3.2
```
I actually think we should err on the side of being lax with peer dependencies. Perhaps we should consider something looser like ">= 0.3.2" or even "*".