### PR TITLE
[docs] Route from react-router is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 Use `<RelayRouter>` or `<RelayRoutingContext>` instead of `<Router>` or `<RoutingContext>` respectively, then define Relay queries and render callbacks for each of your routes:
 
 ```js
+import {Route} from 'react-router';
 import {RelayRouter} from 'react-router-relay';
 
 /* ... */


### PR DESCRIPTION
Hi!

This was not clear from the documentation that `Route` stays original. It took some time for me to realise that, so I propose this addition to make it more visible in the README.