### PR TITLE
forward remaining props to children

### DIFF
--- a/src/RouteContainer.js
+++ b/src/RouteContainer.js
@@ -19,7 +19,7 @@ export default class RouteContainer extends React.Component {
   };
 
   render() {
-    const { Component, createElement, queries, routerProps } = this.props;
+    const { Component, createElement, queries, routerProps, ...others } = this.props;
     const { key, route } = routerProps;
     const { routeAggregator } = this.context;
 
@@ -40,7 +40,7 @@ export default class RouteContainer extends React.Component {
         element = null;
       }
     } else if (fragmentPointers) {
-      const data = { ...routerProps, ...params, ...fragmentPointers };
+      const data = { ...others, ...routerProps, ...params, ...fragmentPointers };
 
       const { renderFetched } = route;
       if (renderFetched) {


### PR DESCRIPTION
Issue introduced from bd9e41e6c2edae090b62f6446be52bb690c74436 that makes passed properties disappear in children.

In all honesty, I don't fully understand how everything is tied together in this project, but I'm guessing it has something to do with this change https://github.com/relay-tools/react-router-relay/commit/bd9e41e6c2edae090b62f6446be52bb690c74436#diff-02147c9abf35e579edc77adcfc038997L20.

Not sure if this is done by design or not, but this fixes the issue in our app. If you want me to provide more context, please let me know.