### PR TITLE
Allow for params to be passed from Route to Components

### DIFF
--- a/src/RelayRouterContext.js
+++ b/src/RelayRouterContext.js
@@ -49,7 +49,7 @@ export default class RelayRouterContext extends React.Component {
 
     const queries = key ? route.queries && route.queries[key] : route.queries;
     if (!queries) {
-      return this.props.createElement(Component, props);
+      return this.props.createElement(Component, { ...props, ...props.route.props });
     }
 
     return (
@@ -59,6 +59,7 @@ export default class RelayRouterContext extends React.Component {
         createElement={this.props.createElement}
         componentKey={key}
         queries={queries}
+        props={route.props}
       />
     );
   };

--- a/src/RouteContainer.js
+++ b/src/RouteContainer.js
@@ -12,6 +12,7 @@ export default class RouteContainer extends React.Component {
     createElement: React.PropTypes.func.isRequired,
     componentKey: React.PropTypes.string,
     queries: React.PropTypes.object.isRequired,
+    props: React.PropTypes.object,
   };
 
   static contextTypes = {
@@ -20,7 +21,7 @@ export default class RouteContainer extends React.Component {
 
   render() {
     const {
-      Component, createElement, componentKey: key, queries, ...routerProps,
+      Component, createElement, componentKey: key, queries, props, ...routerProps,
     } = this.props;
     const { route } = routerProps;
     const { routeAggregator } = this.context;
@@ -42,7 +43,7 @@ export default class RouteContainer extends React.Component {
         element = null;
       }
     } else if (fragmentPointers) {
-      const data = { key, ...routerProps, ...params, ...fragmentPointers };
+      const data = { key, ...props, ...routerProps, ...params, ...fragmentPointers };
 
       const { renderFetched } = route;
       if (renderFetched) {

--- a/test/RelayRouter.spec.js
+++ b/test/RelayRouter.spec.js
@@ -17,11 +17,10 @@ describe('<RelayRouter>', () => {
   });
 
   describe('kitchen sink', () => {
-
     function StaticWidget(props) {
       return (
         <div className={props.static}/>
-      )
+      );
     }
 
     class Widget extends React.Component {
@@ -116,6 +115,5 @@ describe('<RelayRouter>', () => {
     it('should support properties on non-Relay Components', () => {
       ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'Hello');
     });
-
   });
 });

--- a/test/RelayRouter.spec.js
+++ b/test/RelayRouter.spec.js
@@ -17,14 +17,23 @@ describe('<RelayRouter>', () => {
   });
 
   describe('kitchen sink', () => {
+
+    function StaticWidget(props) {
+      return (
+        <div className={props.static}/>
+      )
+    }
+
     class Widget extends React.Component {
       render() {
-        const { widget, first, second } = this.props;
+        const { widget, first, second, third, hello } = this.props;
 
         return (
           <div className={widget.name}>
+            <div className={hello} />
             {first}
             {second}
+            {third}
           </div>
         );
       }
@@ -44,18 +53,20 @@ describe('<RelayRouter>', () => {
       <Route
         path="/"
         component={WidgetContainer}
+        props={{ hello: 'World' }}
         queries={{
           widget: () => Relay.QL`query { widget }`,
         }}
       >
         <Route
           path=":pathName"
-          components={{ first: WidgetContainer, second: WidgetContainer }}
+          components={{ first: WidgetContainer, second: WidgetContainer, third: StaticWidget }}
           queries={{
             first: { widget: () => Relay.QL`query { widgetByArg(name: $pathName) }` },
             second: { widget: () => Relay.QL`query { widgetByArg(name: $queryName) }` },
           }}
           queryParams={['queryName']}
+          props={{ static: 'Hello' }}
         />
       </Route>
     );
@@ -97,5 +108,14 @@ describe('<RelayRouter>', () => {
     it('should support query params', () => {
       ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'baz');
     });
+
+    it('should support properties on RelayContainers', () => {
+      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'World');
+    });
+
+    it('should support properties on non-Relay Components', () => {
+      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'Hello');
+    });
+
   });
 });


### PR DESCRIPTION
This makes it possible to set properties on a Route object that will be
passed to the component(s) inside that route.

For example:

<Route
        path="/"
        component={WidgetContainer}
        props={{ hello: 'World' }}
        queries={{
          widget: () => Relay.QL`query { widget }`,
        }}
      >