### PR TITLE
Switch on RelayRenderer a replacement for Relay.RootContainer

### DIFF
--- a/src/RouteAggregator.js
+++ b/src/RouteAggregator.js
@@ -17,10 +17,6 @@ export default class RouteAggregator {
 
     this.route = null;
     this._fragmentSpecs = null;
-
-    this._failure = null;
-    this._data = {};
-    this._readyState = null;
   }
 
   updateRoute(routerProps) {
@@ -132,26 +128,12 @@ export default class RouteAggregator {
     return `$$_route[${routeIndex}]_${key}_${queryName}`;
   }
 
-  setFailure(error, retry) {
-    this._failure = [error, retry];
-  }
-
-  setFetched(data, readyState) {
-    this._failure = null;
-    this._data = data;
-    this._readyState = readyState;
-  }
-
-  setLoading() {
-    this._failure = null;
-  }
-
-  getData(route, key = DEFAULT_KEY, queries, params) {
+  getData(route, key = DEFAULT_KEY, queries, params, data) {
     // Check that the subset of parameters used for this route match those used
     // for the fetched data.
     for (const paramName of Object.keys(params)) {
-      if (!isEqual(this._data[paramName], params[paramName])) {
-        return this._getDataNotFound();
+      if (!isEqual(data[paramName], params[paramName])) {
+        return {};
       }
     }
 
@@ -159,9 +141,9 @@ export default class RouteAggregator {
     for (const queryName of Object.keys(queries)) {
       const uniqueQueryName = this._getUniqueQueryName(route, key, queryName);
 
-      const fragmentPointer = this._data[uniqueQueryName];
+      const fragmentPointer = data[uniqueQueryName];
       if (!fragmentPointer) {
-        return this._getDataNotFound();
+        return {};
       }
 
       fragmentPointers[queryName] = fragmentPointer;
@@ -169,12 +151,7 @@ export default class RouteAggregator {
 
     return {
       fragmentPointers,
-      readyState: this._readyState,
     };
-  }
-
-  _getDataNotFound() {
-    return { failure: this._failure };
   }
 
   getFragmentNames() {

--- a/test/RelayRouter.spec.js
+++ b/test/RelayRouter.spec.js
@@ -65,10 +65,10 @@ describe('<RelayRouter>', () => {
               widget: () => Relay.QL`query { widgetByArg(name: $queryName) }`,
             },
             third: {
-              widget: () => Relay.QL`query { widgetByArg(name: $pathName) }`,
+              widget: () => Relay.QL`query { widgetByArg(name: $queryName) }`,
             },
           }}
-          renderFetched={{
+          render={{
             third: () => <div className="qux" />,
           }}
           queryParams={['queryName']}
@@ -115,7 +115,7 @@ describe('<RelayRouter>', () => {
       ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'baz');
     });
 
-    it('should support renderFetched', () => {
+    it('should support render', () => {
       ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'qux');
     });
   });


### PR DESCRIPTION
At relay [CHANGELOG](https://github.com/facebook/relay/blob/master/CHANGELOG.md#080-april-11-2016) now oficially written 'Relay.Renderer – a replacement for Relay.RootContainer'. 

Instead of `renderFetched`, `renderLoading` etc just one `render` method on route.

If someone need previous behavior he can use this [lines](https://github.com/facebook/relay/blob/45ed004f7fa29b2fcf575c2d8e7a156a50d7b96c/src/container/RelayRootContainer.js#L114-L131) in render method.

RelayRenderer simplifies some tasks for relay-router
for example drawing loading message without content reset

```
  <Route
    path="/"
    component={App}
    queries={ViewerQueries}
    render={({ props, done }) => (
      <div>
        <div>{done ? 'done' : 'loading'}</div>
        <StaticContainer shouldUpdate={!!props}>
          {props && <App {...props} /> || null}
        </StaticContainer>
      </div>
    )}
  >
```