### PR TITLE
Set Relay fragment null if not exists

### DIFF
--- a/src/RouteContainer.js
+++ b/src/RouteContainer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Relay from 'react-relay';
 import StaticContainer from 'react-static-container';
 
 import RouteAggregator from './RouteAggregator';
@@ -47,6 +48,12 @@ export default class RouteContainer extends React.Component {
       }
     } else if (fragmentPointers) {
       const data = { key, ...routerProps, ...params, ...fragmentPointers };
+
+      if (Relay.isContainer(Component)) {
+        for (const fragmentName of Component.getFragmentNames()) {
+          if (!(fragmentName in data)) data[fragmentName] = null;
+        }
+      }
 
       let { renderFetched } = route;
       if (renderFetched && typeof renderFetched === 'object') {


### PR DESCRIPTION
This useful for dynamic queries in `getQueries`
```
const WidgetContainer = Relay.createContainer(Widget, {
  fragments: {
    a: () => Relay.QL`fragment on A {x, y}`,
    b: () => Relay.QL`fragment on B {x, y}`
  }
});

const widgetRoute = (
  <Route
    path="widgets/:widgetId"
    component={WidgetContainer}
    getQueries={
      (location, params) => location.query.widgetName == 'a' ?
        {a: () => Relay.QL`query {A($id: widgetId)}`} :
        {b: () => Relay.QL`query {B($id: widgetId)}`}
    }
  />
);
```
Without this, I get a warning: 

> RelayContainer: Expected prop `a` to be supplied to `Widget`, but got `undefined`. Pass an explicit `null` if this is intentional.