### PR TITLE
Revert "We're not actually using stage-0"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,11 +4,11 @@
 
   "env": {
     "cjs": {
-      "presets": ["es2015-loose", "stage-1"],
+      "presets": ["es2015-loose", "stage-0"],
       "plugins": ["add-module-exports"]
     },
     "es": {
-      "presets": ["es2015-loose-native-modules", "stage-1"]
+      "presets": ["es2015-loose-native-modules", "stage-0"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-es2015-loose-native-modules": "^1.0.0",
     "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-1": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",
     "babel-relay-plugin": "^0.8.0",
     "chai": "^3.5.0",

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -4,6 +4,6 @@
     { "plugins": ["./fixtures/babelRelayPlugin"] },
     "react",
     "es2015-loose",
-    "stage-1"
+    "stage-0"
   ]
 }

--- a/test/fixtures/.babelrc
+++ b/test/fixtures/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015-loose", "stage-1"]
+  "presets": ["es2015-loose", "stage-0"]
 }


### PR DESCRIPTION
Reverts relay-tools/react-router-relay#151

Turns out Babel doesn't like stage-1 and Relay.