### PR TITLE
Allow passing a function as environment prop in renderRouterContext()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,18 @@ import RouteContainer from './RouteContainer';
 import getRouteQueries from './utils/getRouteQueries';
 
 export default {
-  renderRouterContext: (child, props) => (
-    <RelayRouterContext {...props}>
-      {child}
-    </RelayRouterContext>
-  ),
+  renderRouterContext: (child, props) => {
+    /* eslint-disable react/prop-types */
+    const environment = typeof props.environment === 'function' ?
+      props.environment() : props.environment;
+    /* eslint-enable react/prop-types */
+
+    return (
+      <RelayRouterContext {...Object.assign({}, props, { environment })}>
+        {child}
+      </RelayRouterContext>
+    );
+  },
 
   renderRouteComponent: (child, props) => {
     /* eslint-disable react/prop-types */

--- a/test/useRelay.test.js
+++ b/test/useRelay.test.js
@@ -14,10 +14,15 @@ describe('useRelay', () => {
   let environment;
 
   beforeEach(() => {
-    environment = new Relay.Environment();
-    environment.injectNetworkLayer(
-      new RelayLocalSchema.NetworkLayer({ schema })
-    );
+    environment = () => {
+      const env = new Relay.Environment();
+      env.injectNetworkLayer(
+        new RelayLocalSchema.NetworkLayer({ schema })
+      );
+      return env;
+    };
+    environment = Math.floor(Math.random() * 2) > 0
+      ? environment() : environment;
   });
 
   describe('kitchen sink', () => {


### PR DESCRIPTION
Hi guys and girls,

This is useful to set a new Relay.Environment() for example in login and logout. For example:

```javascript
ReactDOM.render(
  <Router history={browserHistory}
    render={applyRouterMiddleware(useRelay)}
    environment={() => Auth.getEnvironment()}> {/* <------ Hey you!!!*/}
    <Route path="/" component={Hello}/>
    <Route path="/login" component={Login}/>
    <Route path="/admin" component={AdminLayout} onEnter={requireAuth}>
      <IndexRoute component={Hello}/>
      <Route path="star-wars" component={StarWarsApp} queries={StarWarsQueries}/>
      <Route path="graphiql" component={GraphiQL} />
    </Route>
  </Router>,
  document.getElementById('react-root')
);
```

The code for Auth is [here](https://github.com/iporaitech/pwr2-docker/blob/develop/web/static/js/lib/auth.js). You can also see the whole app in there.

Have a nice Friday!

Hisa