### PR TITLE
Add a note to prepareParams docs about pureness

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ const widgetRoute = (
 
 #### Additional parameters
 
-If your queries require additional parameters from the location, such as from the location query or state, you can add those parameters with `prepareParams`. You can also use `prepareParams` to do additional conversion or initialization of your parameters.
+If your queries require additional parameters from the location, such as from the location query or state, you can add those parameters with `prepareParams`. You can also use `prepareParams` to do additional conversion or initialization of your parameters. This function is expected to be pure and return the same result when given the same `params`, `location` and `routes`.
 
 The `prepareParams` method has the same signature and behavior as `prepareParams` on a Relay query config, except that it also receives the current router state as an argument.
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ const widgetRoute = (
 
 #### Additional parameters
 
-If your queries require additional parameters from the location, such as from the location query or state, you can add those parameters with `prepareParams`. You can also use `prepareParams` to do additional conversion or initialization of your parameters. This function is expected to be pure and return the same result when given the same `params`, `location` and `routes`.
+If your queries require additional parameters from the location, such as from the location query or state, you can add those parameters with `prepareParams`. You can also use `prepareParams` to do additional conversion or initialization of your parameters.
 
-The `prepareParams` method has the same signature and behavior as `prepareParams` on a Relay query config, except that it also receives the current router state as an argument.
+The `prepareParams` method has the same signature and behavior as `prepareParams` on a Relay query config, except that it also receives the current router state as an argument. It is expected to return the same result when given the same previous params and router state.
 
 Additionally, you can use route parameters as variables on your containers:
 


### PR DESCRIPTION
`prepareParams` gets called multiple times and if the returned params don't match, the component is simply not rendered. I think ideally there would be a warning, but I would have taken a note in the docs a few hours ago.