### PR TITLE
Modern Relay (Relay 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-relay",
-  "version": "0.13.7",
+  "version": "dev",
   "description": "Relay integration for React Router",
   "files": [
     "es",
@@ -80,7 +80,7 @@
     "mocha": "^3.2.0",
     "react": "^15.5.3",
     "react-dom": "^15.5.3",
-    "react-relay": "^0.10.0",
+    "react-relay": "dev",
     "react-router": "^2.8.0",
     "relay-local-schema": "^0.5.5",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "react": ">=0.14.0",
-    "react-relay": ">=0.6.0",
+    "react-relay": ">=1.0.0-alpha.1",
     "react-router": ">=2.3.0"
   },
   "devDependencies": {
@@ -80,7 +80,7 @@
     "mocha": "^3.2.0",
     "react": "^15.5.3",
     "react-dom": "^15.5.3",
-    "react-relay": "dev",
+    "react-relay": "^1.0.0-rc.1",
     "react-router": "^2.8.0",
     "relay-local-schema": "^0.5.5",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-relay",
-  "version": "dev",
+  "version": "0.14.0-alpha.1",
   "description": "Relay integration for React Router",
   "files": [
     "es",

--- a/src/QueryAggregator.js
+++ b/src/QueryAggregator.js
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 import isEqual from 'lodash/isEqual';
-import Relay from 'react-relay';
+import Relay from 'react-relay/classic';
 
 import getRouteQueries from './utils/getRouteQueries';
 import mergeRouteParams from './utils/mergeRouteParams';

--- a/src/RelayRouterContext.js
+++ b/src/RelayRouterContext.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Relay from 'react-relay';
+import Relay from 'react-relay/classic';
 
 import QueryAggregator from './QueryAggregator';
 

--- a/test/useRelay.test.js
+++ b/test/useRelay.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import Relay from 'react-relay';
+import Relay from 'react-relay/classic';
 import { applyRouterMiddleware, createMemoryHistory, Route, Router }
   from 'react-router';
 import RelayLocalSchema from 'relay-local-schema';


### PR DESCRIPTION
Hey guys,

Relay 2 was released. This PR provides compatibility with the new release. I'm not sure how you would like to handle this, since it's not compatible for users of legacy relay. react-relay and babel released dev versions. I'd hope for react-router-relay to do the same. This is the simplest possible PR to do so. I'll start working on actually integrating Modern Relay with the new API.

Cheers