### PR TITLE
fix typo

### DIFF
--- a/src/QueryAggregator.js
+++ b/src/QueryAggregator.js
@@ -72,7 +72,7 @@ export default class QueryAggregator {
         // for a component that isn't a container.
         invariant(
           Relay.isContainer(component),
-          'relay-router-relay: Route with queries specifies component `%s` ' +
+          'react-router-relay: Route with queries specifies component `%s` ' +
           'that is not a Relay container.',
           component && (component.displayName || component.name),
         );


### PR DESCRIPTION
Got pretty confused when reading an error message from this package that started with "relay-router-relay...". Looks like a typo.